### PR TITLE
run test with dart2wasm and dart2js as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         channel: [stable, beta] # drop master for now, due to https://github.com/pingbird/puro/issues/102
-
+        tools:
+          - {platform: chrome, compiler: dart2js}
+          - {platform: chrome, compiler: dart2wasm}
+          - {platform: vm, compiler: kernel}
     steps:
       - uses: actions/checkout@v4
       - name: Setup runner
@@ -101,4 +104,9 @@ jobs:
           flutter-version: ${{ matrix.channel }}
 
       - name: Run tests
-        run: dart test --reporter=expanded --concurrency=1
+        run: >-
+          dart test 
+          --platform=${{ matrix.tools.platform }} 
+          --compiler=${{ matrix.tools.compiler }} 
+          --reporter=expanded 
+          --concurrency=1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
         "pubspec",
         "puro",
         "pwsh",
-        "Treap",
+        "treap",
         "treaps",
         "upsert"
     ]

--- a/benchmark/set_main.dart
+++ b/benchmark/set_main.dart
@@ -1,3 +1,5 @@
+// Copyright 2024 - 2025, kasper@byolimit.com
+// SPDX-License-Identifier: BSD-3-Clause
 import 'dart:collection';
 import 'dart:math';
 

--- a/example/.vscode/settings.json
+++ b/example/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "Treap"
-    ]
-}

--- a/lib/src/implicit_treap.dart
+++ b/lib/src/implicit_treap.dart
@@ -10,7 +10,7 @@ import 'implicit_algo.dart' as n;
 
 final _rnd = Random();
 typedef _Node<T> = ImmutableNode<T>;
-_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 32));
+_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 31));
 
 @immutable
 final class ImplicitTreap<T> {

--- a/lib/src/implicit_treap.dart
+++ b/lib/src/implicit_treap.dart
@@ -1,16 +1,13 @@
 // Copyright 2024 - 2024, kasper@byolimit.com
 // SPDX-License-Identifier: BSD-3-Clause
-import 'dart:math';
-
 import 'package:meta/meta.dart';
 import 'package:treap/src/node.dart';
 
 import 'immutable_node.dart';
 import 'implicit_algo.dart' as n;
 
-final _rnd = Random();
 typedef _Node<T> = ImmutableNode<T>;
-_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 31));
+_Node<T> _createNode<T>(T item) => _Node<T>(item, defaultPriority(item));
 
 @immutable
 final class ImplicitTreap<T> {

--- a/lib/src/node.dart
+++ b/lib/src/node.dart
@@ -1,5 +1,6 @@
 // Copyright 2024 - 2024, kasper@byolimit.com
 // SPDX-License-Identifier: BSD-3-Clause
+import 'dart:math';
 
 final class NodeContext<T, NodeT extends Node<T, NodeT>> {
   final Comparator<T> compare;
@@ -20,6 +21,14 @@ abstract class Node<T, NodeT extends Node<T, NodeT>> {
   NodeT withItem(T item);
   NodeT copy();
 }
+
+final _rnd = Random();
+int randomPriority(Object? item) =>
+    _rnd.nextInt(0xffff + 1); // dart2js friendly version of 1 << 32 (2^32)
+
+int hashAsPriority(Object? i) => Object.hash(i, 1202);
+
+var defaultPriority = hashAsPriority;
 
 Never _noElement() => throw StateError('No element');
 

--- a/lib/src/treap_base.dart
+++ b/lib/src/treap_base.dart
@@ -1,14 +1,11 @@
-import 'dart:math';
-
 import 'package:meta/meta.dart';
 
 import 'immutable_node.dart';
 import 'node.dart';
 import 'node.dart' as node;
 
-final _rnd = Random();
 typedef _Node<T> = ImmutableNode<T>;
-_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 31));
+_Node<T> _createNode<T>(T item) => _Node<T>(item, defaultPriority(item));
 
 /// A [fully persistent](https://en.wikipedia.org/wiki/Persistent_data_structure)
 /// (immutable) implementation of a [Treap](https://en.wikipedia.org/wiki/Treap).

--- a/lib/src/treap_map.dart
+++ b/lib/src/treap_map.dart
@@ -1,16 +1,14 @@
 // Copyright 2024 - 2024, kasper@byolimit.com
 // SPDX-License-Identifier: BSD-3-Clause
 import 'dart:collection';
-import 'dart:math';
 
 import 'immutable_node.dart';
 import 'node.dart';
 
-final _rnd = Random();
 typedef _Item<K, V> = ({K key, V? value});
 typedef _Node<K, V> = ImmutableNode<_Item<K, V>>;
 _Node<K, V> _createNode<K, V>(_Item<K, V> item) =>
-    _Node(item, _rnd.nextInt(1 << 31));
+    _Node(item, defaultPriority(item));
 
 class TreapMap<K, V> extends MapBase<K, V> {
   _Node<K, V>? _root;

--- a/lib/src/treap_map.dart
+++ b/lib/src/treap_map.dart
@@ -10,7 +10,7 @@ final _rnd = Random();
 typedef _Item<K, V> = ({K key, V? value});
 typedef _Node<K, V> = ImmutableNode<_Item<K, V>>;
 _Node<K, V> _createNode<K, V>(_Item<K, V> item) =>
-    _Node(item, _rnd.nextInt(1 << 32));
+    _Node(item, _rnd.nextInt(1 << 31));
 
 class TreapMap<K, V> extends MapBase<K, V> {
   _Node<K, V>? _root;

--- a/lib/src/treap_set.dart
+++ b/lib/src/treap_set.dart
@@ -9,7 +9,7 @@ import 'node.dart' as node;
 
 typedef _Node<T> = ImmutableNode<T>;
 final _rnd = Random();
-_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 32));
+_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 31));
 
 class TreapSet<T> extends SetBase<T> {
   _Node<T>? _root;

--- a/lib/src/treap_set.dart
+++ b/lib/src/treap_set.dart
@@ -1,15 +1,13 @@
 // Copyright 2024 - 2024, kasper@byolimit.com
 // SPDX-License-Identifier: BSD-3-Clause
 import 'dart:collection';
-import 'dart:math';
 
 import 'immutable_node.dart';
 import 'node.dart';
 import 'node.dart' as node;
 
 typedef _Node<T> = ImmutableNode<T>;
-final _rnd = Random();
-_Node<T> _createNode<T>(T item) => _Node<T>(item, _rnd.nextInt(1 << 31));
+_Node<T> _createNode<T>(T item) => _Node<T>(item, defaultPriority(item));
 
 class TreapSet<T> extends SetBase<T> {
   _Node<T>? _root;

--- a/test/dartdoc_test.dart
+++ b/test/dartdoc_test.dart
@@ -1,4 +1,8 @@
+@TestOn('vm')
+library;
+
 import 'package:dartdoc_test/dartdoc_test.dart';
+import 'package:test/test.dart';
 
 /// Test code samples in documentation comments in this package.
 ///

--- a/test/treap_test.dart
+++ b/test/treap_test.dart
@@ -191,7 +191,7 @@ void main() {
   group('Node', () {
     final rnd = Random(42);
     ImmutableNode<int> node(int value) =>
-        ImmutableNode<int>(value, rnd.nextInt(1 << 32));
+        ImmutableNode<int>(value, rnd.nextInt(1 << 31));
 
     final ctx = NodeContext(
       Comparable.compare as Comparator<int>,
@@ -223,7 +223,7 @@ void main() {
 
       final fifth = erase(forth, 0, ctx);
       expect(fifth!.inOrder().map((n) => n.item), [1, 2, 3]);
-      expect(identical(third, fifth), false);
+      expect(identical(third, fifth), true); // depends..
 
       expect(
         erase(forth, 2, ctx)!.inOrder().map((n) => n.item),

--- a/test/treap_test.dart
+++ b/test/treap_test.dart
@@ -59,6 +59,21 @@ void main() {
         expect(t, copy); // for an immutable treap, this is true too
         expect(identical(t, copy), isTrue);
       });
+
+      for (final priority in [
+        randomPriority, // old default
+        hashAsPriority, // current default
+        (Object? i) => i as int, // "works" for ints, but easy to unbalance
+        (Object? i) => 0, // "works", but badly unbalanced
+      ]) {
+        test('defaultPriority = $priority', () {
+          defaultPriority = priority;
+          const max = 1000;
+          final items = [for (int i = 0; i < max; ++i) i]..mix();
+          final t = Treap.of(items);
+          expect(t.values, items..sort());
+        });
+      }
     });
 
     group('retrieval', () {


### PR DESCRIPTION
- Added matrix configuration in CI to run tests with dart2wasm and dart2js on different platforms.
- Refactored to use `defaultPriority` instead of `Random` for setting priority on node creation.
- Added `randomPriority`, `hashAsPriority`, and `defaultPriority` for modular priority generation.